### PR TITLE
Refine checkout and build/link process of libcgroup

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,15 +1,14 @@
-
 MRuby::Gem::Specification.new('mruby-cgroup') do |spec|
   spec.license = 'MIT'
   spec.authors = 'MATSUMOTO Ryosuke'
   spec.linker.libraries << ['pthread', 'rt']
 
-  def is_in_linux?
+  def cgroup_available?
     `grep -q cpu /proc/self/cgroup`
     $?.success?
   end
 
-  unless is_in_linux?
+  unless cgroup_available?
     puts "skip libcgroup build"
     next
   end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,7 +1,7 @@
 MRuby::Gem::Specification.new('mruby-cgroup') do |spec|
   spec.license = 'MIT'
   spec.authors = 'MATSUMOTO Ryosuke'
-  spec.linker.libraries << ['pthread', 'rt']
+  spec.linker.libraries.concat ['pthread', 'rt']
 
   def cgroup_available?
     `grep -q cpu /proc/self/cgroup`
@@ -15,49 +15,53 @@ MRuby::Gem::Specification.new('mruby-cgroup') do |spec|
 
   require 'open3'
 
-  libcgroup_dir = "#{build_dir}/libcgroup"
-  libcgroup_build_dir = "#{build_dir}/libcgroup/build"
+  def libcgroup_dir(b); "#{b.build_dir}/libcgroup"; end
+  def libcgroup_build_dir(b); "#{b.build_dir}/libcgroup/build"; end
 
   task :clean do
-    FileUtils.rm_rf [libcgroup_dir]
+    FileUtils.rm_rf [libcgroup_dir(build)]
   end
 
   def run_command env, command
     STDOUT.sync = true
-    puts "build: [exec] #{command}"
+    puts "EXEC\t[mruby-cgroup] #{command}"
     Open3.popen2e(env, command) do |stdin, stdout, thread|
       print stdout.read
       fail "#{command} failed" if thread.value != 0
     end
   end
 
-  FileUtils.mkdir_p build_dir
+  file libcgroup_dir(build) do
+    FileUtils.mkdir_p build.build_dir
 
-  if ! File.exists? libcgroup_dir
-    Dir.chdir(build_dir) do
-      e = {}
-      run_command e, 'git clone git://github.com/matsumoto-r/libcgroup.git'
+    unless File.exists? libcgroup_dir(build)
+      Dir.chdir(build.build_dir) do
+        e = {}
+        run_command e, 'git clone git://github.com/matsumoto-r/libcgroup.git'
+      end
     end
   end
 
-  if ! File.exists? "#{libcgroup_build_dir}/lib/libcgroup.a"
-    Dir.chdir libcgroup_dir do
+  file libfile("#{libcgroup_build_dir(build)}/lib/libcgroup") => libcgroup_dir(build) do
+    Dir.chdir libcgroup_dir(build) do
       e = {
         'CC' => "#{spec.build.cc.command} #{spec.build.cc.flags.join(' ')}",
         'CXX' => "#{spec.build.cxx.command} #{spec.build.cxx.flags.join(' ')}",
         'LD' => "#{spec.build.linker.command} #{spec.build.linker.flags.join(' ')}",
         'AR' => spec.build.archiver.command,
-        'PREFIX' => libcgroup_build_dir
+        'PREFIX' => libcgroup_build_dir(build)
       }
 
       run_command e, "git checkout ce167ed16147bb68fa1b31633b19de77780d5f2b ."
       run_command e, "autoreconf --force --install"
-      run_command e, "./configure --prefix=#{libcgroup_build_dir} --enable-static"
+      run_command e, "./configure --prefix=#{libcgroup_build_dir(build)} --enable-static"
       run_command e, "make"
       run_command e, "make install"
     end
   end
 
-  spec.cc.include_paths << "#{libcgroup_build_dir}/include"
-  spec.linker.flags_before_libraries << "#{libcgroup_build_dir}/lib/libcgroup.a"
+  file libfile("#{build.build_dir}/lib/libmruby") => libfile("#{libcgroup_build_dir(build)}/lib/libcgroup")
+
+  spec.cc.include_paths << "#{libcgroup_build_dir(build)}/include"
+  spec.linker.flags_before_libraries << libfile("#{libcgroup_build_dir(build)}/lib/libcgroup")
 end


### PR DESCRIPTION
Currently, mruby-cgroup tries to checkout libcgroup.git even when it is not a build task.
This is because linkage processes are defined on the toplevel.

I've fixed this by re-defining the process as rake dependencies. So the process will be invoked only when compiling.
## refs:
- https://github.com/udzura/mruby-argtable/blob/static-link-argtable3/mrbgem.rake
- https://github.com/mattn/mruby-onig-regexp/blob/master/mrbgem.rake
