### PR TITLE
Revert "Bump libcgroup commitish"

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -52,7 +52,7 @@ MRuby::Gem::Specification.new('mruby-cgroup') do |spec|
         'PREFIX' => libcgroup_build_dir(build)
       }
 
-      run_command e, "git checkout 5f1e3a0ca268fea7adcd2469379b98e048f1527d ."
+      run_command e, "git checkout ce167ed16147bb68fa1b31633b19de77780d5f2b ."
       run_command e, "autoreconf --force --install"
       run_command e, "./configure --prefix=#{libcgroup_build_dir(build)} --enable-static --disable-shared"
       run_command e, "make"


### PR DESCRIPTION
This reverts commit ce319428258b7a07068b9f9cc2d680232bf1a1ea.

The commit included in https://github.com/matsumotory/mruby-cgroup/pull/8 creates warnings like:

```
Error: failed to set /sys/fs/cgroup/cpu,cpuacct/cpu-quota-test/cpu.stat: Invalid argument
Error: failed to set /sys/fs/cgroup/cpu,cpuacct/cpu-quota-test/cpuacct.usage_percpu: Invalid argument
Error: failed to set /sys/fs/cgroup/cpu,cpuacct/cpu-quota-test/cpuacct.stat: Invalid argument
Error: failed to set /sys/fs/cgroup/cpu,cpuacct/cpu-quota-test/cpuacct.usage: Invalid argument
```

This is because of libcgroup upgrade. I want to suppress these.