### PR TITLE
Add name attribute in ruby level

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 # requires clang-format >= 3.6
 BasedOnStyle: "LLVM"
 IndentWidth: 4
-ColumnLimit: 100
+ColumnLimit: 120
 BreakBeforeBraces: Linux
 AllowShortFunctionsOnASingleLine: None

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+# requires clang-format >= 3.6
+BasedOnStyle: "LLVM"
+IndentWidth: 4
+ColumnLimit: 100
+BreakBeforeBraces: Linux
+AllowShortFunctionsOnASingleLine: None

--- a/src/mrb_cgroup.c
+++ b/src/mrb_cgroup.c
@@ -198,6 +198,16 @@ static mrb_value mrb_cgroup_attach(mrb_state *mrb, mrb_value self)
     return self;
 }
 
+static mrb_value mrb_cgroup_group_name(mrb_state *mrb, mrb_value self)
+{
+    mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");
+    if (mrb_cg_cxt) {
+        return mrb_cg_cxt->group_name;
+    } else {
+        return mrb_nil_value();
+    }
+}
+
 //
 // init
 //
@@ -633,6 +643,7 @@ void mrb_mruby_cgroup_gem_init(mrb_state *mrb)
     //mrb_define_module_function(mrb, cgroup, "path", mrb_cgroup_get_current_path, MRB_ARGS_OPT(1));
     mrb_define_module_function(mrb, cgroup, "exist?", mrb_cgroup_exist_p, MRB_ARGS_NONE());
     mrb_define_module_function(mrb, cgroup, "attach", mrb_cgroup_attach, MRB_ARGS_ANY());
+    mrb_define_module_function(mrb, cgroup, "group_name", mrb_cgroup_group_name, MRB_ARGS_NONE());
     DONE;
 
     cpu = mrb_define_class_under(mrb, cgroup, "CPU", mrb->object_class);

--- a/src/mrb_cgroup.c
+++ b/src/mrb_cgroup.c
@@ -25,20 +25,20 @@
 ** [ MIT license: http://www.opensource.org/licenses/mit-license.php ]
 */
 
+#include <ctype.h>
 #include <libcgroup.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <ctype.h>
 
 #include "mruby.h"
-#include "mruby/data.h"
-#include "mruby/variable.h"
 #include "mruby/array.h"
-#include "mruby/string.h"
 #include "mruby/class.h"
+#include "mruby/data.h"
 #include "mruby/numeric.h"
+#include "mruby/string.h"
+#include "mruby/variable.h"
 
 #define BLKIO_STRING_SIZE 64
 #define DONE mrb_gc_arena_restore(mrb, 0);
@@ -68,7 +68,7 @@ typedef struct {
 static void mrb_cgroup_context_free(mrb_state *mrb, void *p)
 {
     mrb_cgroup_context *ctx = p;
-//    cgroup_free_controllers(c->cg);
+    //    cgroup_free_controllers(c->cg);
     cgroup_free(&ctx->cg);
 }
 
@@ -76,7 +76,7 @@ static const struct mrb_data_type mrb_cgroup_context_type = {
     "mrb_cgroup_context", mrb_cgroup_context_free,
 };
 
-static mrb_cgroup_context *mrb_cgroup_get_context(mrb_state *mrb,  mrb_value self, const char *ctx_flag)
+static mrb_cgroup_context *mrb_cgroup_get_context(mrb_state *mrb, mrb_value self, const char *ctx_flag)
 {
     mrb_cgroup_context *c;
     mrb_value context;
@@ -99,7 +99,9 @@ static mrb_value mrb_cgroup_create(mrb_state *mrb, mrb_value self)
     mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");
 
     // BUG1 : cgroup_create_cgroup returns an error(Invalid argument:50016:ECGOTHER), despite actually succeeding
-    // BUG2 : cgroup_delete_cgroup returns an error(This kernel does not support this feature:50029:ECGCANTSETVALUE), despite actually succeeding
+    // BUG2 : cgroup_delete_cgroup returns an error(This kernel does not support this
+    // feature:50029:ECGCANTSETVALUE),
+    // despite actually succeeding
     // REFS : libcgroup/src/api.c 1620 - 1630 comments
     //
     //        error = cg_set_control_value(path,
@@ -125,23 +127,12 @@ static mrb_value mrb_cgroup_create(mrb_state *mrb, mrb_value self)
     //
 
     if ((code = cgroup_create_cgroup(mrb_cg_cxt->cg, 1)) && code != ECGOTHER && code != ECGCANTSETVALUE) {
-        mrb_raisef(mrb
-            , E_RUNTIME_ERROR
-            , "cgroup_create failed: %S(%S)"
-            , mrb_str_new_cstr(mrb, cgroup_strerror(code))
-            , mrb_fixnum_value(code)
-        );
+        mrb_raisef(mrb, E_RUNTIME_ERROR, "cgroup_create failed: %S(%S)", mrb_str_new_cstr(mrb, cgroup_strerror(code)),
+                   mrb_fixnum_value(code));
     }
     mrb_cg_cxt->already_exist = 1;
-    mrb_iv_set(mrb
-        , self
-        , mrb_intern_cstr(mrb, "mrb_cgroup_context")
-        , mrb_obj_value(Data_Wrap_Struct(mrb
-            , mrb->object_class
-            , &mrb_cgroup_context_type
-            , (void *)mrb_cg_cxt)
-        )
-    );
+    mrb_iv_set(mrb, self, mrb_intern_cstr(mrb, "mrb_cgroup_context"),
+               mrb_obj_value(Data_Wrap_Struct(mrb, mrb->object_class, &mrb_cgroup_context_type, (void *)mrb_cg_cxt)));
 
     return self;
 }
@@ -151,14 +142,11 @@ static mrb_value mrb_cgroup_delete(mrb_state *mrb, mrb_value self)
     int code;
     mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");
 
-    // BUG1 : cgroup_delete_cgroup returns an error(No such file or directory:50016:ECGOTHER), despite actually succeeding
+    // BUG1 : cgroup_delete_cgroup returns an error(No such file or directory:50016:ECGOTHER), despite actually
+    // succeeding
     if ((code = cgroup_delete_cgroup(mrb_cg_cxt->cg, 1)) && code != ECGOTHER) {
-        mrb_raisef(mrb
-            , E_RUNTIME_ERROR
-            , "cgroup_delete faild: %S(%S)"
-            , mrb_str_new_cstr(mrb, cgroup_strerror(code))
-            , mrb_fixnum_value(code)
-        );
+        mrb_raisef(mrb, E_RUNTIME_ERROR, "cgroup_delete faild: %S(%S)", mrb_str_new_cstr(mrb, cgroup_strerror(code)),
+                   mrb_fixnum_value(code));
     }
 
     return self;
@@ -167,11 +155,11 @@ static mrb_value mrb_cgroup_delete(mrb_state *mrb, mrb_value self)
 static mrb_value mrb_cgroup_exist_p(mrb_state *mrb, mrb_value self)
 {
     mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");
-    return (mrb_cg_cxt->already_exist) ? mrb_true_value(): mrb_false_value();
+    return (mrb_cg_cxt->already_exist) ? mrb_true_value() : mrb_false_value();
 }
 
 //
-//task
+// task
 //
 
 static mrb_value mrb_cgroup_attach(mrb_state *mrb, mrb_value self)
@@ -185,15 +173,8 @@ static mrb_value mrb_cgroup_attach(mrb_state *mrb, mrb_value self)
     } else {
         cgroup_attach_task_pid(mrb_cg_cxt->cg, mrb_fixnum(pid));
     }
-    mrb_iv_set(mrb
-        , self
-        , mrb_intern_cstr(mrb, "mrb_cgroup_context")
-        , mrb_obj_value(Data_Wrap_Struct(mrb
-            , mrb->object_class
-            , &mrb_cgroup_context_type
-            , (void *)mrb_cg_cxt)
-        )
-    );
+    mrb_iv_set(mrb, self, mrb_intern_cstr(mrb, "mrb_cgroup_context"),
+               mrb_obj_value(Data_Wrap_Struct(mrb, mrb->object_class, &mrb_cgroup_context_type, (void *)mrb_cg_cxt)));
 
     return self;
 }
@@ -211,49 +192,43 @@ static mrb_value mrb_cgroup_group_name(mrb_state *mrb, mrb_value self)
 //
 // init
 //
-#define SET_MRB_CGROUP_INIT_GROUP(gname) \
-static mrb_value mrb_cgroup_##gname##_init(mrb_state *mrb, mrb_value self)                                      \
-{                                                                                                               \
-    mrb_cgroup_context *mrb_cg_cxt = (mrb_cgroup_context *)mrb_malloc(mrb, sizeof(mrb_cgroup_context));         \
-                                                                                                                \
-    mrb_cg_cxt->type = MRB_CGROUP_##gname;                                                                      \
-    if (cgroup_init()) {                                                                                        \
-        mrb_raise(mrb, E_RUNTIME_ERROR, "cgoup_init " #gname " failed");                                        \
-    }                                                                                                           \
-    mrb_get_args(mrb, "o", &mrb_cg_cxt->group_name);                                                            \
-    mrb_cg_cxt->cg = cgroup_new_cgroup(RSTRING_PTR(mrb_cg_cxt->group_name));                                    \
-    if (mrb_cg_cxt->cg == NULL) {                                                                               \
-        mrb_raise(mrb, E_RUNTIME_ERROR, "cgoup_new_cgroup failed");                                             \
-    }                                                                                                           \
-                                                                                                                \
-    if (cgroup_get_cgroup(mrb_cg_cxt->cg)) {                                                                    \
-        mrb_cg_cxt->already_exist = 0;                                                                          \
-        mrb_cg_cxt->cgc = cgroup_add_controller(mrb_cg_cxt->cg, #gname);                                        \
-        if (mrb_cg_cxt->cgc == NULL) {                                                                          \
-            mrb_raise(mrb, E_RUNTIME_ERROR, "cgoup_add_controller " #gname " failed");                          \
-        }                                                                                                       \
-    } else {                                                                                                    \
-        mrb_cg_cxt->already_exist = 1;                                                                          \
-        mrb_cg_cxt->cgc = cgroup_get_controller(mrb_cg_cxt->cg, #gname);                                        \
-        if (mrb_cg_cxt->cgc == NULL) {                                                                          \
-            mrb_cg_cxt->cgc = cgroup_add_controller(mrb_cg_cxt->cg, #gname);                                    \
-            if (mrb_cg_cxt->cgc == NULL) {                                                                      \
-                mrb_raise(mrb, E_RUNTIME_ERROR, "get_cgroup success, but add_controller "  #gname " failed");   \
-            }                                                                                                   \
-        }                                                                                                       \
-    }                                                                                                           \
-    mrb_iv_set(mrb                                                                                              \
-        , self                                                                                                  \
-        , mrb_intern_cstr(mrb, "mrb_cgroup_context")                                                                 \
-        , mrb_obj_value(Data_Wrap_Struct(mrb                                                                    \
-            , mrb->object_class                                                                                 \
-            , &mrb_cgroup_context_type                                                                          \
-            , (void *)mrb_cg_cxt)                                                                               \
-        )                                                                                                       \
-    );                                                                                                          \
-                                                                                                                \
-    return self;                                                                                                \
-}
+#define SET_MRB_CGROUP_INIT_GROUP(gname)                                                                               \
+    static mrb_value mrb_cgroup_##gname##_init(mrb_state *mrb, mrb_value self)                                         \
+    {                                                                                                                  \
+        mrb_cgroup_context *mrb_cg_cxt = (mrb_cgroup_context *)mrb_malloc(mrb, sizeof(mrb_cgroup_context));            \
+                                                                                                                       \
+        mrb_cg_cxt->type = MRB_CGROUP_##gname;                                                                         \
+        if (cgroup_init()) {                                                                                           \
+            mrb_raise(mrb, E_RUNTIME_ERROR, "cgoup_init " #gname " failed");                                           \
+        }                                                                                                              \
+        mrb_get_args(mrb, "o", &mrb_cg_cxt->group_name);                                                               \
+        mrb_cg_cxt->cg = cgroup_new_cgroup(RSTRING_PTR(mrb_cg_cxt->group_name));                                       \
+        if (mrb_cg_cxt->cg == NULL) {                                                                                  \
+            mrb_raise(mrb, E_RUNTIME_ERROR, "cgoup_new_cgroup failed");                                                \
+        }                                                                                                              \
+                                                                                                                       \
+        if (cgroup_get_cgroup(mrb_cg_cxt->cg)) {                                                                       \
+            mrb_cg_cxt->already_exist = 0;                                                                             \
+            mrb_cg_cxt->cgc = cgroup_add_controller(mrb_cg_cxt->cg, #gname);                                           \
+            if (mrb_cg_cxt->cgc == NULL) {                                                                             \
+                mrb_raise(mrb, E_RUNTIME_ERROR, "cgoup_add_controller " #gname " failed");                             \
+            }                                                                                                          \
+        } else {                                                                                                       \
+            mrb_cg_cxt->already_exist = 1;                                                                             \
+            mrb_cg_cxt->cgc = cgroup_get_controller(mrb_cg_cxt->cg, #gname);                                           \
+            if (mrb_cg_cxt->cgc == NULL) {                                                                             \
+                mrb_cg_cxt->cgc = cgroup_add_controller(mrb_cg_cxt->cg, #gname);                                       \
+                if (mrb_cg_cxt->cgc == NULL) {                                                                         \
+                    mrb_raise(mrb, E_RUNTIME_ERROR, "get_cgroup success, but add_controller " #gname " failed");       \
+                }                                                                                                      \
+            }                                                                                                          \
+        }                                                                                                              \
+        mrb_iv_set(                                                                                                    \
+            mrb, self, mrb_intern_cstr(mrb, "mrb_cgroup_context"),                                                     \
+            mrb_obj_value(Data_Wrap_Struct(mrb, mrb->object_class, &mrb_cgroup_context_type, (void *)mrb_cg_cxt)));    \
+                                                                                                                       \
+        return self;                                                                                                   \
+    }
 
 SET_MRB_CGROUP_INIT_GROUP(cpu);
 SET_MRB_CGROUP_INIT_GROUP(cpuset);
@@ -265,29 +240,24 @@ SET_MRB_CGROUP_INIT_GROUP(pids);
 //
 // cgroup_set_value_int64
 //
-#define SET_VALUE_INT64_MRB_CGROUP(gname, key) \
-static mrb_value mrb_cgroup_set_##gname##_##key(mrb_state *mrb, mrb_value self)                      \
-{                                                                                             \
-    mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context"); \
-    mrb_value val;                                                                              \
-    int code;                                                                                 \
-    mrb_get_args(mrb, "o", &val);                                                             \
-                                                                                              \
-    if ((code = cgroup_set_value_int64(mrb_cg_cxt->cgc, #gname "." #key, (int64_t)mrb_to_flo(mrb, val)))) {                      \
-        mrb_raisef(mrb, E_RUNTIME_ERROR, "cgroup_set_value_int64 " #gname "." #key " failed: %S", mrb_str_new_cstr(mrb, cgroup_strerror(code))); \
-    }                                                                                         \
-    mrb_iv_set(mrb                                                                            \
-        , self                                                                                \
-        , mrb_intern_cstr(mrb, "mrb_cgroup_context")                                               \
-        , mrb_obj_value(Data_Wrap_Struct(mrb                                                  \
-            , mrb->object_class                                                               \
-            , &mrb_cgroup_context_type                                                        \
-            , (void *)mrb_cg_cxt)                                                             \
-        )                                                                                     \
-    );                                                                                        \
-                                                                                              \
-    return self;                                                                              \
-}
+#define SET_VALUE_INT64_MRB_CGROUP(gname, key)                                                                         \
+    static mrb_value mrb_cgroup_set_##gname##_##key(mrb_state *mrb, mrb_value self)                                    \
+    {                                                                                                                  \
+        mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");                      \
+        mrb_value val;                                                                                                 \
+        int code;                                                                                                      \
+        mrb_get_args(mrb, "o", &val);                                                                                  \
+                                                                                                                       \
+        if ((code = cgroup_set_value_int64(mrb_cg_cxt->cgc, #gname "." #key, (int64_t)mrb_to_flo(mrb, val)))) {        \
+            mrb_raisef(mrb, E_RUNTIME_ERROR, "cgroup_set_value_int64 " #gname "." #key " failed: %S",                  \
+                       mrb_str_new_cstr(mrb, cgroup_strerror(code)));                                                  \
+        }                                                                                                              \
+        mrb_iv_set(                                                                                                    \
+            mrb, self, mrb_intern_cstr(mrb, "mrb_cgroup_context"),                                                     \
+            mrb_obj_value(Data_Wrap_Struct(mrb, mrb->object_class, &mrb_cgroup_context_type, (void *)mrb_cg_cxt)));    \
+                                                                                                                       \
+        return self;                                                                                                   \
+    }
 
 SET_VALUE_INT64_MRB_CGROUP(cpu, cfs_quota_us);
 SET_VALUE_INT64_MRB_CGROUP(cpu, cfs_period_us);
@@ -298,26 +268,22 @@ SET_VALUE_INT64_MRB_CGROUP(cpuacct, usage);
 SET_VALUE_INT64_MRB_CGROUP(memory, limit_in_bytes);
 SET_VALUE_INT64_MRB_CGROUP(pids, max);
 
-#define GET_VALUE_INT64_MRB_CGROUP(gname, key) \
-static mrb_value mrb_cgroup_get_##gname##_##key(mrb_state *mrb, mrb_value self)                      \
-{                                                                                             \
-    mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context"); \
-    int64_t val;                                                                              \
-    int code;                                                                                 \
-    if ((code = cgroup_get_value_int64(mrb_cg_cxt->cgc, #gname "." #key, &val)) && code != ECGROUPVALUENOTEXIST) {            \
-        mrb_raisef(mrb \
-            , E_RUNTIME_ERROR \
-            , "cgroup_get_value_int64 " #gname "." #key " failed: %S(%S)" \
-            , mrb_str_new_cstr(mrb, cgroup_strerror(code)) \
-            , mrb_fixnum_value(code) \
-        ); \
-    }                                                                                         \
-    if (code == ECGROUPVALUENOTEXIST) {\
-        return mrb_nil_value();\
-    } else {\
-        return mrb_fixnum_value(val);                                                             \
-    }\
-}
+#define GET_VALUE_INT64_MRB_CGROUP(gname, key)                                                                         \
+    static mrb_value mrb_cgroup_get_##gname##_##key(mrb_state *mrb, mrb_value self)                                    \
+    {                                                                                                                  \
+        mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");                      \
+        int64_t val;                                                                                                   \
+        int code;                                                                                                      \
+        if ((code = cgroup_get_value_int64(mrb_cg_cxt->cgc, #gname "." #key, &val)) && code != ECGROUPVALUENOTEXIST) { \
+            mrb_raisef(mrb, E_RUNTIME_ERROR, "cgroup_get_value_int64 " #gname "." #key " failed: %S(%S)",              \
+                       mrb_str_new_cstr(mrb, cgroup_strerror(code)), mrb_fixnum_value(code));                          \
+        }                                                                                                              \
+        if (code == ECGROUPVALUENOTEXIST) {                                                                            \
+            return mrb_nil_value();                                                                                    \
+        } else {                                                                                                       \
+            return mrb_fixnum_value(val);                                                                              \
+        }                                                                                                              \
+    }
 
 GET_VALUE_INT64_MRB_CGROUP(cpu, cfs_quota_us);
 GET_VALUE_INT64_MRB_CGROUP(cpu, cfs_period_us);
@@ -334,27 +300,24 @@ GET_VALUE_INT64_MRB_CGROUP(pids, max);
 //
 // cgroup_get_value_string
 //
-#define GET_VALUE_STRING_MRB_CGROUP(gname, key) \
-static mrb_value mrb_cgroup_get_##gname##_##key(mrb_state *mrb, mrb_value self)               \
-{                                                                                             \
-    int code;                                                                                 \
-    char *val;                                                                                \
-    mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context"); \
-                                                                                              \
-    if ((code = cgroup_get_value_string(mrb_cg_cxt->cgc , #gname "." #key, &val)) != 0 && code != ECGROUPVALUENOTEXIST) {     \
-        mrb_raisef(mrb                                                                        \
-            , E_RUNTIME_ERROR                                                                 \
-            , "cgroup_get_value_string " #gname "." #key " failed: %S(%S)"                        \
-            , mrb_str_new_cstr(mrb, cgroup_strerror(code))                                    \
-            , mrb_fixnum_value(code)                                    \
-        );                                                                                    \
-    }                                                                                         \
-    if (strcmp(val, "")) {                                                                    \
-        return mrb_str_new_cstr(mrb, val);                                                    \
-    } else {                                                                                  \
-        return  mrb_nil_value();                                                              \
-    }                                                                                         \
-}
+#define GET_VALUE_STRING_MRB_CGROUP(gname, key)                                                                        \
+    static mrb_value mrb_cgroup_get_##gname##_##key(mrb_state *mrb, mrb_value self)                                    \
+    {                                                                                                                  \
+        int code;                                                                                                      \
+        char *val;                                                                                                     \
+        mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");                      \
+                                                                                                                       \
+        if ((code = cgroup_get_value_string(mrb_cg_cxt->cgc, #gname "." #key, &val)) != 0 &&                           \
+            code != ECGROUPVALUENOTEXIST) {                                                                            \
+            mrb_raisef(mrb, E_RUNTIME_ERROR, "cgroup_get_value_string " #gname "." #key " failed: %S(%S)",             \
+                       mrb_str_new_cstr(mrb, cgroup_strerror(code)), mrb_fixnum_value(code));                          \
+        }                                                                                                              \
+        if (strcmp(val, "")) {                                                                                         \
+            return mrb_str_new_cstr(mrb, val);                                                                         \
+        } else {                                                                                                       \
+            return mrb_nil_value();                                                                                    \
+        }                                                                                                              \
+    }
 
 GET_VALUE_STRING_MRB_CGROUP(cpu, stat);
 GET_VALUE_STRING_MRB_CGROUP(cpuset, cpus);
@@ -365,27 +328,24 @@ GET_VALUE_STRING_MRB_CGROUP(cpuacct, usage_percpu);
 //
 // cgroup_get_value_string (a number of keys are 2)
 //
-#define GET_VALUE_STRING_MRB_CGROUP_KEY2(gname, key1, key2) \
-static mrb_value mrb_cgroup_get_##gname##_##key1##_##key2(mrb_state *mrb, mrb_value self)               \
-{                                                                                                       \
-    int code;                                                                                           \
-    char *val;                                                                                          \
-    mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");           \
-                                                                                                        \
-    if ((code = cgroup_get_value_string(mrb_cg_cxt->cgc , #gname "." #key1 "." #key2, &val)) != 0 && code != ECGROUPVALUENOTEXIST) {    \
-        mrb_raisef(mrb                                                                                  \
-            , E_RUNTIME_ERROR                                                                           \
-            , "cgroup_get_value_string " #gname "." #key1 "." #key2 " failed: %S(%S)"                   \
-            , mrb_str_new_cstr(mrb, cgroup_strerror(code))                                              \
-            , mrb_fixnum_value(code)                                    \
-        );                                                                                              \
-    }                                                                                                   \
-    if (strcmp(val, "")) {                                                                              \
-        return mrb_str_new_cstr(mrb, val);                                                              \
-    } else {                                                                                            \
-        return  mrb_nil_value();                                                                        \
-    }                                                                                                   \
-}
+#define GET_VALUE_STRING_MRB_CGROUP_KEY2(gname, key1, key2)                                                            \
+    static mrb_value mrb_cgroup_get_##gname##_##key1##_##key2(mrb_state *mrb, mrb_value self)                          \
+    {                                                                                                                  \
+        int code;                                                                                                      \
+        char *val;                                                                                                     \
+        mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");                      \
+                                                                                                                       \
+        if ((code = cgroup_get_value_string(mrb_cg_cxt->cgc, #gname "." #key1 "." #key2, &val)) != 0 &&                \
+            code != ECGROUPVALUENOTEXIST) {                                                                            \
+            mrb_raisef(mrb, E_RUNTIME_ERROR, "cgroup_get_value_string " #gname "." #key1 "." #key2 " failed: %S(%S)",  \
+                       mrb_str_new_cstr(mrb, cgroup_strerror(code)), mrb_fixnum_value(code));                          \
+        }                                                                                                              \
+        if (strcmp(val, "")) {                                                                                         \
+            return mrb_str_new_cstr(mrb, val);                                                                         \
+        } else {                                                                                                       \
+            return mrb_nil_value();                                                                                    \
+        }                                                                                                              \
+    }
 
 GET_VALUE_STRING_MRB_CGROUP_KEY2(blkio, throttle, read_bps_device);
 GET_VALUE_STRING_MRB_CGROUP_KEY2(blkio, throttle, write_bps_device);
@@ -395,27 +355,24 @@ GET_VALUE_STRING_MRB_CGROUP_KEY2(blkio, throttle, write_iops_device);
 //
 // cgroup_get_value_int64 (a number of keys are 2)
 //
-#define GET_VALUE_INT64_MRB_CGROUP_KEY2(gname, key1, key2) \
-static mrb_value mrb_cgroup_get_##gname##_##key1##_##key2(mrb_state *mrb, mrb_value self)               \
-{                                                                                                       \
-    int code;                                                                                           \
-    int64_t val;                                                                                          \
-    mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");           \
-                                                                                                        \
-    if ((code = cgroup_get_value_int64(mrb_cg_cxt->cgc , #gname "." #key1 "." #key2, &val)) != 0 && code != ECGROUPVALUENOTEXIST) {    \
-        mrb_raisef(mrb                                                                                  \
-            , E_RUNTIME_ERROR                                                                           \
-            , "cgroup_get_value_int64 " #gname "." #key1 "." #key2 " failed: %S(%S)"                   \
-            , mrb_str_new_cstr(mrb, cgroup_strerror(code))                                              \
-            , mrb_fixnum_value(code)                                    \
-        );                                                                                              \
-    }                                                                                                   \
-    if (code == ECGROUPVALUENOTEXIST) {\
-        return mrb_nil_value();\
-    } else {\
-        return mrb_fixnum_value(val);                                                             \
-    }\
-}
+#define GET_VALUE_INT64_MRB_CGROUP_KEY2(gname, key1, key2)                                                             \
+    static mrb_value mrb_cgroup_get_##gname##_##key1##_##key2(mrb_state *mrb, mrb_value self)                          \
+    {                                                                                                                  \
+        int code;                                                                                                      \
+        int64_t val;                                                                                                   \
+        mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");                      \
+                                                                                                                       \
+        if ((code = cgroup_get_value_int64(mrb_cg_cxt->cgc, #gname "." #key1 "." #key2, &val)) != 0 &&                 \
+            code != ECGROUPVALUENOTEXIST) {                                                                            \
+            mrb_raisef(mrb, E_RUNTIME_ERROR, "cgroup_get_value_int64 " #gname "." #key1 "." #key2 " failed: %S(%S)",   \
+                       mrb_str_new_cstr(mrb, cgroup_strerror(code)), mrb_fixnum_value(code));                          \
+        }                                                                                                              \
+        if (code == ECGROUPVALUENOTEXIST) {                                                                            \
+            return mrb_nil_value();                                                                                    \
+        } else {                                                                                                       \
+            return mrb_fixnum_value(val);                                                                              \
+        }                                                                                                              \
+    }
 
 GET_VALUE_INT64_MRB_CGROUP_KEY2(memory, memsw, limit_in_bytes);
 GET_VALUE_INT64_MRB_CGROUP_KEY2(memory, memsw, usage_in_bytes);
@@ -424,32 +381,22 @@ GET_VALUE_INT64_MRB_CGROUP_KEY2(memory, memsw, max_usage_in_bytes);
 //
 // cgroup_set_value_string
 //
-#define SET_VALUE_STRING_MRB_CGROUP(gname, key) \
-static mrb_value mrb_cgroup_set_##gname##_##key(mrb_state *mrb, mrb_value self)                           \
-{                                                                                                         \
-    mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");             \
-    int code;                                                                                             \
-    char *val;                                                                                            \
-    mrb_get_args(mrb, "z", &val);                                                                         \
-    if ((code = cgroup_set_value_string(mrb_cg_cxt->cgc , #gname "." #key , val))) {                      \
-        mrb_raisef(mrb                                                                                    \
-            , E_RUNTIME_ERROR                                                                             \
-            , "cgroup_set_value_string " #gname "." #key " failed: %S(%S)"                                \
-            , mrb_str_new_cstr(mrb, cgroup_strerror(code))                                                \
-            , mrb_fixnum_value(code)                                                                      \
-        );                                                                                                \
-    }                                                                                                     \
-    mrb_iv_set(mrb                                                                                        \
-        , self                                                                                            \
-        , mrb_intern_cstr(mrb, "mrb_cgroup_context")                                                           \
-        , mrb_obj_value(Data_Wrap_Struct(mrb                                                              \
-            , mrb->object_class                                                                           \
-            , &mrb_cgroup_context_type                                                                    \
-            , (void *)mrb_cg_cxt)                                                                         \
-        )                                                                                                 \
-    );                                                                                                    \
-    return self;                                                                                          \
-}
+#define SET_VALUE_STRING_MRB_CGROUP(gname, key)                                                                        \
+    static mrb_value mrb_cgroup_set_##gname##_##key(mrb_state *mrb, mrb_value self)                                    \
+    {                                                                                                                  \
+        mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");                      \
+        int code;                                                                                                      \
+        char *val;                                                                                                     \
+        mrb_get_args(mrb, "z", &val);                                                                                  \
+        if ((code = cgroup_set_value_string(mrb_cg_cxt->cgc, #gname "." #key, val))) {                                 \
+            mrb_raisef(mrb, E_RUNTIME_ERROR, "cgroup_set_value_string " #gname "." #key " failed: %S(%S)",             \
+                       mrb_str_new_cstr(mrb, cgroup_strerror(code)), mrb_fixnum_value(code));                          \
+        }                                                                                                              \
+        mrb_iv_set(                                                                                                    \
+            mrb, self, mrb_intern_cstr(mrb, "mrb_cgroup_context"),                                                     \
+            mrb_obj_value(Data_Wrap_Struct(mrb, mrb->object_class, &mrb_cgroup_context_type, (void *)mrb_cg_cxt)));    \
+        return self;                                                                                                   \
+    }
 
 SET_VALUE_STRING_MRB_CGROUP(cpuset, cpus);
 SET_VALUE_STRING_MRB_CGROUP(cpuset, mems);
@@ -457,32 +404,22 @@ SET_VALUE_STRING_MRB_CGROUP(cpuset, mems);
 //
 // cgroup_set_value_string (a number of keys are 2)
 //
-#define SET_VALUE_STRING_MRB_CGROUP_KEY2(gname, key1, key2) \
-static mrb_value mrb_cgroup_set_##gname##_##key1##_##key2(mrb_state *mrb, mrb_value self)                 \
-{                                                                                                         \
-    mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");             \
-    int code;                                                                                             \
-    char *val;                                                                                            \
-    mrb_get_args(mrb, "z", &val);                                                                         \
-    if ((code = cgroup_set_value_string(mrb_cg_cxt->cgc , #gname "." #key1 "." #key2 , val)) != 0) {      \
-        mrb_raisef(mrb                                                                                    \
-            , E_RUNTIME_ERROR                                                                             \
-            , "cgroup_set_value_string " #gname "." #key1 "." #key2 " failed: %S(%S)"                     \
-            , mrb_str_new_cstr(mrb, cgroup_strerror(code))                                                \
-            , mrb_fixnum_value(code)                                                                      \
-        );                                                                                                \
-    }                                                                                                     \
-    mrb_iv_set(mrb                                                                                        \
-        , self                                                                                            \
-        , mrb_intern_cstr(mrb, "mrb_cgroup_context")                                                           \
-        , mrb_obj_value(Data_Wrap_Struct(mrb                                                              \
-            , mrb->object_class                                                                           \
-            , &mrb_cgroup_context_type                                                                    \
-            , (void *)mrb_cg_cxt)                                                                         \
-        )                                                                                                 \
-    );                                                                                                    \
-    return self;                                                                                          \
-}
+#define SET_VALUE_STRING_MRB_CGROUP_KEY2(gname, key1, key2)                                                            \
+    static mrb_value mrb_cgroup_set_##gname##_##key1##_##key2(mrb_state *mrb, mrb_value self)                          \
+    {                                                                                                                  \
+        mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");                      \
+        int code;                                                                                                      \
+        char *val;                                                                                                     \
+        mrb_get_args(mrb, "z", &val);                                                                                  \
+        if ((code = cgroup_set_value_string(mrb_cg_cxt->cgc, #gname "." #key1 "." #key2, val)) != 0) {                 \
+            mrb_raisef(mrb, E_RUNTIME_ERROR, "cgroup_set_value_string " #gname "." #key1 "." #key2 " failed: %S(%S)",  \
+                       mrb_str_new_cstr(mrb, cgroup_strerror(code)), mrb_fixnum_value(code));                          \
+        }                                                                                                              \
+        mrb_iv_set(                                                                                                    \
+            mrb, self, mrb_intern_cstr(mrb, "mrb_cgroup_context"),                                                     \
+            mrb_obj_value(Data_Wrap_Struct(mrb, mrb->object_class, &mrb_cgroup_context_type, (void *)mrb_cg_cxt)));    \
+        return self;                                                                                                   \
+    }
 
 SET_VALUE_STRING_MRB_CGROUP_KEY2(blkio, throttle, read_bps_device);
 SET_VALUE_STRING_MRB_CGROUP_KEY2(blkio, throttle, write_bps_device);
@@ -492,116 +429,87 @@ SET_VALUE_STRING_MRB_CGROUP_KEY2(blkio, throttle, write_iops_device);
 //
 // cgroup_set_value_int64 (a number of keys are 2)
 //
-#define SET_VALUE_INT64_CGROUP_KEY2(gname, key1, key2) \
-static mrb_value mrb_cgroup_set_##gname##_##key1##_##key2(mrb_state *mrb, mrb_value self)                 \
-{                                                                                                         \
-    mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");             \
-    int code;                                                                                             \
-    mrb_value val;                                                                                            \
-    mrb_get_args(mrb, "o", &val);                                                                         \
-    if ((code = cgroup_set_value_int64(mrb_cg_cxt->cgc , #gname "." #key1 "." #key2 , mrb_fixnum(val))) != 0) {      \
-        mrb_raisef(mrb                                                                                    \
-            , E_RUNTIME_ERROR                                                                             \
-            , "cgroup_set_value_int64 " #gname "." #key1 "." #key2 " failed: %S(%S)"                     \
-            , mrb_str_new_cstr(mrb, cgroup_strerror(code))                                                \
-            , mrb_fixnum_value(code)                                                                      \
-        );                                                                                                \
-    }                                                                                                     \
-    mrb_iv_set(mrb                                                                                        \
-        , self                                                                                            \
-        , mrb_intern_cstr(mrb, "mrb_cgroup_context")                                                           \
-        , mrb_obj_value(Data_Wrap_Struct(mrb                                                              \
-            , mrb->object_class                                                                           \
-            , &mrb_cgroup_context_type                                                                    \
-            , (void *)mrb_cg_cxt)                                                                         \
-        )                                                                                                 \
-    );                                                                                                    \
-    return self;                                                                                          \
-}
+#define SET_VALUE_INT64_CGROUP_KEY2(gname, key1, key2)                                                                 \
+    static mrb_value mrb_cgroup_set_##gname##_##key1##_##key2(mrb_state *mrb, mrb_value self)                          \
+    {                                                                                                                  \
+        mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");                      \
+        int code;                                                                                                      \
+        mrb_value val;                                                                                                 \
+        mrb_get_args(mrb, "o", &val);                                                                                  \
+        if ((code = cgroup_set_value_int64(mrb_cg_cxt->cgc, #gname "." #key1 "." #key2, mrb_fixnum(val))) != 0) {      \
+            mrb_raisef(mrb, E_RUNTIME_ERROR, "cgroup_set_value_int64 " #gname "." #key1 "." #key2 " failed: %S(%S)",   \
+                       mrb_str_new_cstr(mrb, cgroup_strerror(code)), mrb_fixnum_value(code));                          \
+        }                                                                                                              \
+        mrb_iv_set(                                                                                                    \
+            mrb, self, mrb_intern_cstr(mrb, "mrb_cgroup_context"),                                                     \
+            mrb_obj_value(Data_Wrap_Struct(mrb, mrb->object_class, &mrb_cgroup_context_type, (void *)mrb_cg_cxt)));    \
+        return self;                                                                                                   \
+    }
 
 SET_VALUE_INT64_CGROUP_KEY2(memory, memsw, limit_in_bytes);
 
 //
 // cgroup_set_value_string (a number of keys are 2)
 //
-#define SET_VALUE_STRING_MRB_CGROUP_KEY2_NOT_USE_GNAME(gname, key1, key2) \
-static mrb_value mrb_cgroup_set_##gname##_##key1##_##key2(mrb_state *mrb, mrb_value self)                 \
-{                                                                                                         \
-    mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");             \
-    int code;                                                                                             \
-    char *val;                                                                                            \
-    mrb_get_args(mrb, "z", &val);                                                                         \
-    if ((code = cgroup_set_value_string(mrb_cg_cxt->cgc , #key1 "." #key2 , val)) != 0) {                 \
-        mrb_raisef(mrb                                                                                    \
-            , E_RUNTIME_ERROR                                                                             \
-            , "cgroup_set_value_string " #key1 "." #key2 " failed: %S(%S)"                                \
-            , mrb_str_new_cstr(mrb, cgroup_strerror(code))                                                \
-            , mrb_fixnum_value(code)                                                                      \
-        );                                                                                                \
-    }                                                                                                     \
-    mrb_iv_set(mrb                                                                                        \
-        , self                                                                                            \
-        , mrb_intern_cstr(mrb, "mrb_cgroup_context")                                                      \
-        , mrb_obj_value(Data_Wrap_Struct(mrb                                                              \
-            , mrb->object_class                                                                           \
-            , &mrb_cgroup_context_type                                                                    \
-            , (void *)mrb_cg_cxt)                                                                         \
-        )                                                                                                 \
-    );                                                                                                    \
-    return self;                                                                                          \
-}
+#define SET_VALUE_STRING_MRB_CGROUP_KEY2_NOT_USE_GNAME(gname, key1, key2)                                              \
+    static mrb_value mrb_cgroup_set_##gname##_##key1##_##key2(mrb_state *mrb, mrb_value self)                          \
+    {                                                                                                                  \
+        mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");                      \
+        int code;                                                                                                      \
+        char *val;                                                                                                     \
+        mrb_get_args(mrb, "z", &val);                                                                                  \
+        if ((code = cgroup_set_value_string(mrb_cg_cxt->cgc, #key1 "." #key2, val)) != 0) {                            \
+            mrb_raisef(mrb, E_RUNTIME_ERROR, "cgroup_set_value_string " #key1 "." #key2 " failed: %S(%S)",             \
+                       mrb_str_new_cstr(mrb, cgroup_strerror(code)), mrb_fixnum_value(code));                          \
+        }                                                                                                              \
+        mrb_iv_set(                                                                                                    \
+            mrb, self, mrb_intern_cstr(mrb, "mrb_cgroup_context"),                                                     \
+            mrb_obj_value(Data_Wrap_Struct(mrb, mrb->object_class, &mrb_cgroup_context_type, (void *)mrb_cg_cxt)));    \
+        return self;                                                                                                   \
+    }
 
 SET_VALUE_STRING_MRB_CGROUP_KEY2_NOT_USE_GNAME(memory, cgroup, event_control);
 
 //
 // cgroup_set_bool
 //
-#define SET_VALUE_BOOL_MRB_CGROUP(gname, key) \
-static mrb_value mrb_cgroup_set_##gname##_##key(mrb_state *mrb, mrb_value self)                      \
-{                                                                                             \
-    mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context"); \
-    mrb_bool val;                                                                              \
-    int code;                                                                                 \
-    mrb_get_args(mrb, "b", &val);                                                             \
-                                                                                              \
-    if ((code = cgroup_set_value_bool(mrb_cg_cxt->cgc, #gname "." #key, (bool)val))) {                      \
-        mrb_raisef(mrb, E_RUNTIME_ERROR, "cgroup_set_value_book " #gname "." #key " failed: %S", mrb_str_new_cstr(mrb, cgroup_strerror(code))); \
-    }                                                                                         \
-    mrb_iv_set(mrb                                                                            \
-        , self                                                                                \
-        , mrb_intern_cstr(mrb, "mrb_cgroup_context")                                               \
-        , mrb_obj_value(Data_Wrap_Struct(mrb                                                  \
-            , mrb->object_class                                                               \
-            , &mrb_cgroup_context_type                                                        \
-            , (void *)mrb_cg_cxt)                                                             \
-        )                                                                                     \
-    );                                                                                        \
-                                                                                              \
-    return self;                                                                              \
-}
+#define SET_VALUE_BOOL_MRB_CGROUP(gname, key)                                                                          \
+    static mrb_value mrb_cgroup_set_##gname##_##key(mrb_state *mrb, mrb_value self)                                    \
+    {                                                                                                                  \
+        mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");                      \
+        mrb_bool val;                                                                                                  \
+        int code;                                                                                                      \
+        mrb_get_args(mrb, "b", &val);                                                                                  \
+                                                                                                                       \
+        if ((code = cgroup_set_value_bool(mrb_cg_cxt->cgc, #gname "." #key, (bool)val))) {                             \
+            mrb_raisef(mrb, E_RUNTIME_ERROR, "cgroup_set_value_book " #gname "." #key " failed: %S",                   \
+                       mrb_str_new_cstr(mrb, cgroup_strerror(code)));                                                  \
+        }                                                                                                              \
+        mrb_iv_set(                                                                                                    \
+            mrb, self, mrb_intern_cstr(mrb, "mrb_cgroup_context"),                                                     \
+            mrb_obj_value(Data_Wrap_Struct(mrb, mrb->object_class, &mrb_cgroup_context_type, (void *)mrb_cg_cxt)));    \
+                                                                                                                       \
+        return self;                                                                                                   \
+    }
 
 SET_VALUE_BOOL_MRB_CGROUP(memory, oom_control);
 
-#define GET_VALUE_BOOL_MRB_CGROUP(gname, key) \
-static mrb_value mrb_cgroup_get_##gname##_##key(mrb_state *mrb, mrb_value self)                      \
-{                                                                                             \
-    mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context"); \
-    bool val;                                                                              \
-    int code;                                                                                 \
-    if ((code = cgroup_get_value_bool(mrb_cg_cxt->cgc, #gname "." #key, &val)) && code != ECGROUPVALUENOTEXIST) {            \
-        mrb_raisef(mrb \
-            , E_RUNTIME_ERROR \
-            , "cgroup_get_value_bool " #gname "." #key " failed: %S(%S)" \
-            , mrb_str_new_cstr(mrb, cgroup_strerror(code)) \
-            , mrb_fixnum_value(code) \
-        ); \
-    }                                                                                         \
-    if (code == ECGROUPVALUENOTEXIST) {\
-        return mrb_nil_value();\
-    } else {\
-        return mrb_bool_value(val);                                                             \
-    }\
-}
+#define GET_VALUE_BOOL_MRB_CGROUP(gname, key)                                                                          \
+    static mrb_value mrb_cgroup_get_##gname##_##key(mrb_state *mrb, mrb_value self)                                    \
+    {                                                                                                                  \
+        mrb_cgroup_context *mrb_cg_cxt = mrb_cgroup_get_context(mrb, self, "mrb_cgroup_context");                      \
+        bool val;                                                                                                      \
+        int code;                                                                                                      \
+        if ((code = cgroup_get_value_bool(mrb_cg_cxt->cgc, #gname "." #key, &val)) && code != ECGROUPVALUENOTEXIST) {  \
+            mrb_raisef(mrb, E_RUNTIME_ERROR, "cgroup_get_value_bool " #gname "." #key " failed: %S(%S)",               \
+                       mrb_str_new_cstr(mrb, cgroup_strerror(code)), mrb_fixnum_value(code));                          \
+        }                                                                                                              \
+        if (code == ECGROUPVALUENOTEXIST) {                                                                            \
+            return mrb_nil_value();                                                                                    \
+        } else {                                                                                                       \
+            return mrb_bool_value(val);                                                                                \
+        }                                                                                                              \
+    }
 
 GET_VALUE_BOOL_MRB_CGROUP(memory, oom_control);
 
@@ -614,7 +522,8 @@ static mrb_value mrb_cgroup_get_cpuacct_obj(mrb_state *mrb, mrb_value self)
     cpuacct_value = mrb_iv_get(mrb, self, mrb_intern_cstr(mrb, "cpuacct_obj"));
     if (mrb_nil_p(cpuacct_value)) {
         cgroup_class = mrb_class_get(mrb, "Cgroup");
-        cpuacct_class = (struct RClass*)mrb_class_ptr(mrb_const_get(mrb, mrb_obj_value(cgroup_class), mrb_intern_cstr(mrb, "CPUACCT")));
+        cpuacct_class = (struct RClass *)mrb_class_ptr(
+            mrb_const_get(mrb, mrb_obj_value(cgroup_class), mrb_intern_cstr(mrb, "CPUACCT")));
         cpuacct_value = mrb_obj_new(mrb, cpuacct_class, 1, &mrb_cg_cxt->group_name);
         mrb_iv_set(mrb, self, mrb_intern_cstr(mrb, "cpuacct_obj"), cpuacct_value);
     }
@@ -633,14 +542,15 @@ void mrb_mruby_cgroup_gem_init(mrb_state *mrb)
 
     cgroup = mrb_define_module(mrb, "Cgroup");
     mrb_define_module_function(mrb, cgroup, "create", mrb_cgroup_create, MRB_ARGS_NONE());
-    // BUG? cgroup_modify_cgroup fail fclose on cg_set_control_value: line:1389 when get existing cgroup controller
-    //mrb_define_module_function(mrb, cgroup, "modify", mrb_cgroup_modify, MRB_ARGS_NONE());
+    // BUG? cgroup_modify_cgroup fail fclose on cg_set_control_value: line:1389 when get existing cgroup
+    // controller
+    // mrb_define_module_function(mrb, cgroup, "modify", mrb_cgroup_modify, MRB_ARGS_NONE());
     mrb_define_module_function(mrb, cgroup, "modify", mrb_cgroup_create, MRB_ARGS_NONE());
     mrb_define_module_function(mrb, cgroup, "open", mrb_cgroup_create, MRB_ARGS_NONE());
     mrb_define_module_function(mrb, cgroup, "delete", mrb_cgroup_delete, MRB_ARGS_NONE());
     mrb_define_module_function(mrb, cgroup, "close", mrb_cgroup_delete, MRB_ARGS_NONE());
     mrb_define_module_function(mrb, cgroup, "attach", mrb_cgroup_attach, MRB_ARGS_OPT(1));
-    //mrb_define_module_function(mrb, cgroup, "path", mrb_cgroup_get_current_path, MRB_ARGS_OPT(1));
+    // mrb_define_module_function(mrb, cgroup, "path", mrb_cgroup_get_current_path, MRB_ARGS_OPT(1));
     mrb_define_module_function(mrb, cgroup, "exist?", mrb_cgroup_exist_p, MRB_ARGS_NONE());
     mrb_define_module_function(mrb, cgroup, "attach", mrb_cgroup_attach, MRB_ARGS_ANY());
     mrb_define_module_function(mrb, cgroup, "group_name", mrb_cgroup_group_name, MRB_ARGS_NONE());
@@ -652,11 +562,11 @@ void mrb_mruby_cgroup_gem_init(mrb_state *mrb)
     mrb_define_method(mrb, cpu, "cfs_quota_us=", mrb_cgroup_set_cpu_cfs_quota_us, MRB_ARGS_ANY());
     mrb_define_method(mrb, cpu, "cfs_quota_us", mrb_cgroup_get_cpu_cfs_quota_us, MRB_ARGS_NONE());
     mrb_define_method(mrb, cpu, "cfs_period_us=", mrb_cgroup_set_cpu_cfs_period_us, MRB_ARGS_ANY());
-    mrb_define_method(mrb, cpu, "cfs_period_us",  mrb_cgroup_get_cpu_cfs_period_us, MRB_ARGS_NONE());
+    mrb_define_method(mrb, cpu, "cfs_period_us", mrb_cgroup_get_cpu_cfs_period_us, MRB_ARGS_NONE());
     mrb_define_method(mrb, cpu, "rt_period_us=", mrb_cgroup_set_cpu_rt_period_us, MRB_ARGS_ANY());
-    mrb_define_method(mrb, cpu, "rt_period_us",  mrb_cgroup_get_cpu_rt_period_us, MRB_ARGS_NONE());
+    mrb_define_method(mrb, cpu, "rt_period_us", mrb_cgroup_get_cpu_rt_period_us, MRB_ARGS_NONE());
     mrb_define_method(mrb, cpu, "rt_runtime_us=", mrb_cgroup_set_cpu_rt_runtime_us, MRB_ARGS_ANY());
-    mrb_define_method(mrb, cpu, "rt_runtime_us",  mrb_cgroup_get_cpu_rt_runtime_us, MRB_ARGS_NONE());
+    mrb_define_method(mrb, cpu, "rt_runtime_us", mrb_cgroup_get_cpu_rt_runtime_us, MRB_ARGS_NONE());
     mrb_define_method(mrb, cpu, "shares=", mrb_cgroup_set_cpu_shares, MRB_ARGS_ANY());
     mrb_define_method(mrb, cpu, "shares", mrb_cgroup_get_cpu_shares, MRB_ARGS_NONE());
     mrb_define_method(mrb, cpu, "stat", mrb_cgroup_get_cpu_stat, MRB_ARGS_NONE());
@@ -669,29 +579,37 @@ void mrb_mruby_cgroup_gem_init(mrb_state *mrb)
     mrb_define_method(mrb, cpuacct, "stat", mrb_cgroup_get_cpuacct_stat, MRB_ARGS_NONE());
     mrb_define_method(mrb, cpuacct, "usage", mrb_cgroup_get_cpuacct_usage, MRB_ARGS_NONE());
     mrb_define_method(mrb, cpuacct, "usage=", mrb_cgroup_set_cpuacct_usage, MRB_ARGS_REQ(1));
-    mrb_define_method(mrb, cpuacct, "usage_percpu",  mrb_cgroup_get_cpuacct_usage_percpu, MRB_ARGS_NONE());
+    mrb_define_method(mrb, cpuacct, "usage_percpu", mrb_cgroup_get_cpuacct_usage_percpu, MRB_ARGS_NONE());
     DONE;
 
     cpuset = mrb_define_class_under(mrb, cgroup, "CPUSET", mrb->object_class);
     mrb_include_module(mrb, cpuset, mrb_module_get(mrb, "Cgroup"));
     mrb_define_method(mrb, cpuset, "initialize", mrb_cgroup_cpuset_init, MRB_ARGS_ANY());
     mrb_define_method(mrb, cpuset, "cpus=", mrb_cgroup_set_cpuset_cpus, MRB_ARGS_REQ(1));
-    mrb_define_method(mrb, cpuset, "cpus",  mrb_cgroup_get_cpuset_cpus, MRB_ARGS_NONE());
+    mrb_define_method(mrb, cpuset, "cpus", mrb_cgroup_get_cpuset_cpus, MRB_ARGS_NONE());
     mrb_define_method(mrb, cpuset, "mems=", mrb_cgroup_set_cpuset_mems, MRB_ARGS_REQ(1));
-    mrb_define_method(mrb, cpuset, "mems",  mrb_cgroup_get_cpuset_mems, MRB_ARGS_NONE());
+    mrb_define_method(mrb, cpuset, "mems", mrb_cgroup_get_cpuset_mems, MRB_ARGS_NONE());
     DONE;
 
     blkio = mrb_define_class_under(mrb, cgroup, "BLKIO", mrb->object_class);
     mrb_include_module(mrb, blkio, mrb_module_get(mrb, "Cgroup"));
     mrb_define_method(mrb, blkio, "initialize", mrb_cgroup_blkio_init, MRB_ARGS_ANY());
-    mrb_define_method(mrb, blkio, "throttle_read_bps_device=", mrb_cgroup_set_blkio_throttle_read_bps_device, MRB_ARGS_ANY());
-    mrb_define_method(mrb, blkio, "throttle_read_bps_device", mrb_cgroup_get_blkio_throttle_read_bps_device, MRB_ARGS_NONE());
-    mrb_define_method(mrb, blkio, "throttle_write_bps_device=", mrb_cgroup_set_blkio_throttle_write_bps_device, MRB_ARGS_ANY());
-    mrb_define_method(mrb, blkio, "throttle_write_bps_device", mrb_cgroup_get_blkio_throttle_write_bps_device, MRB_ARGS_ANY());
-    mrb_define_method(mrb, blkio, "throttle_read_iops_device=", mrb_cgroup_set_blkio_throttle_read_iops_device, MRB_ARGS_ANY());
-    mrb_define_method(mrb, blkio, "throttle_read_iops_device", mrb_cgroup_get_blkio_throttle_read_iops_device, MRB_ARGS_NONE());
-    mrb_define_method(mrb, blkio, "throttle_write_iops_device=", mrb_cgroup_set_blkio_throttle_write_iops_device, MRB_ARGS_ANY());
-    mrb_define_method(mrb, blkio, "throttle_write_iops_device", mrb_cgroup_get_blkio_throttle_write_iops_device, MRB_ARGS_NONE());
+    mrb_define_method(mrb, blkio, "throttle_read_bps_device=", mrb_cgroup_set_blkio_throttle_read_bps_device,
+                      MRB_ARGS_ANY());
+    mrb_define_method(mrb, blkio, "throttle_read_bps_device", mrb_cgroup_get_blkio_throttle_read_bps_device,
+                      MRB_ARGS_NONE());
+    mrb_define_method(mrb, blkio, "throttle_write_bps_device=", mrb_cgroup_set_blkio_throttle_write_bps_device,
+                      MRB_ARGS_ANY());
+    mrb_define_method(mrb, blkio, "throttle_write_bps_device", mrb_cgroup_get_blkio_throttle_write_bps_device,
+                      MRB_ARGS_ANY());
+    mrb_define_method(mrb, blkio, "throttle_read_iops_device=", mrb_cgroup_set_blkio_throttle_read_iops_device,
+                      MRB_ARGS_ANY());
+    mrb_define_method(mrb, blkio, "throttle_read_iops_device", mrb_cgroup_get_blkio_throttle_read_iops_device,
+                      MRB_ARGS_NONE());
+    mrb_define_method(mrb, blkio, "throttle_write_iops_device=", mrb_cgroup_set_blkio_throttle_write_iops_device,
+                      MRB_ARGS_ANY());
+    mrb_define_method(mrb, blkio, "throttle_write_iops_device", mrb_cgroup_get_blkio_throttle_write_iops_device,
+                      MRB_ARGS_NONE());
     DONE;
 
     memory = mrb_define_class_under(mrb, cgroup, "MEMORY", mrb->object_class);
@@ -707,7 +625,8 @@ void mrb_mruby_cgroup_gem_init(mrb_state *mrb)
     mrb_define_method(mrb, memory, "memsw_limit_in_bytes=", mrb_cgroup_set_memory_memsw_limit_in_bytes, MRB_ARGS_ANY());
     mrb_define_method(mrb, memory, "memsw_limit_in_bytes", mrb_cgroup_get_memory_memsw_limit_in_bytes, MRB_ARGS_NONE());
     mrb_define_method(mrb, memory, "memsw_usage_in_bytes", mrb_cgroup_get_memory_memsw_usage_in_bytes, MRB_ARGS_NONE());
-    mrb_define_method(mrb, memory, "memsw_max_usage_in_bytes", mrb_cgroup_get_memory_memsw_max_usage_in_bytes, MRB_ARGS_NONE());
+    mrb_define_method(mrb, memory, "memsw_max_usage_in_bytes", mrb_cgroup_get_memory_memsw_max_usage_in_bytes,
+                      MRB_ARGS_NONE());
     DONE;
 
     pids = mrb_define_class_under(mrb, cgroup, "PIDS", mrb->object_class);
@@ -722,4 +641,3 @@ void mrb_mruby_cgroup_gem_init(mrb_state *mrb)
 void mrb_mruby_cgroup_gem_final(mrb_state *mrb)
 {
 }
-


### PR DESCRIPTION
Added just a wrapper to context :)

```ruby
> cpu = Cgroup::CPU.new('example001')
 #=> #<Cgroup::CPU:0xe92e00 mrb_cgroup_context=#<Object:0xe92dd0>>
> cpu.group_name
 #=> "example001"
```