### PR TITLE
Handle ECGROUPVALUENOTEXIST when accessing string attribute

### DIFF
--- a/src/mrb_cgroup.c
+++ b/src/mrb_cgroup.c
@@ -312,10 +312,10 @@ GET_VALUE_INT64_MRB_CGROUP(pids, max);
             mrb_raisef(mrb, E_RUNTIME_ERROR, "cgroup_get_value_string " #gname "." #key " failed: %S(%S)",             \
                        mrb_str_new_cstr(mrb, cgroup_strerror(code)), mrb_fixnum_value(code));                          \
         }                                                                                                              \
-        if (strcmp(val, "")) {                                                                                         \
-            return mrb_str_new_cstr(mrb, val);                                                                         \
-        } else {                                                                                                       \
+        if (code == ECGROUPVALUENOTEXIST || !strcmp(val, "")) {                                                        \
             return mrb_nil_value();                                                                                    \
+        } else {                                                                                                       \
+            return mrb_str_new_cstr(mrb, val);                                                                         \
         }                                                                                                              \
     }
 
@@ -340,10 +340,10 @@ GET_VALUE_STRING_MRB_CGROUP(cpuacct, usage_percpu);
             mrb_raisef(mrb, E_RUNTIME_ERROR, "cgroup_get_value_string " #gname "." #key1 "." #key2 " failed: %S(%S)",  \
                        mrb_str_new_cstr(mrb, cgroup_strerror(code)), mrb_fixnum_value(code));                          \
         }                                                                                                              \
-        if (strcmp(val, "")) {                                                                                         \
-            return mrb_str_new_cstr(mrb, val);                                                                         \
-        } else {                                                                                                       \
+        if (code == ECGROUPVALUENOTEXIST || !strcmp(val, "")) {                                                        \
             return mrb_nil_value();                                                                                    \
+        } else {                                                                                                       \
+            return mrb_str_new_cstr(mrb, val);                                                                         \
         }                                                                                                              \
     }
 


### PR DESCRIPTION
Before:

```console
## No cgroup of /sys/fs/cgroup/cpu/example
$ ./mruby/bin/mruby -e "Cgroup::CPU.new('example').stat"                                                                                  
Segmentation fault
```

After:

```console
$ ./mruby/bin/mruby -e "p Cgroup::CPU.new('example').stat"
nil

$ sudo ./mruby/bin/mruby -e "c = Cgroup::CPU.new('example'); c.create; p Cgroup::CPU.new('example').stat"
"nr_periods 0\nnr_throttled 0\nthrottled_time 0"
```