### PR TITLE
mruby 1.3.0、masterに対応

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,9 @@ before_install:
 install:
   - sudo apt-get -qq install rake bison git gperf libpam0g-dev autotools-dev cgroup-lite
   - gem install rake
+env:
+  - MRUBY_VERSION=1.2.0
+  - MRUBY_VERSION=1.3.0
+  - MRUBY_VERSION=master
 script:
   - rake

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 MRUBY_CONFIG=File.expand_path(ENV["MRUBY_CONFIG"] || "build_config.rb")
-MRUBY_VERSION=ENV["MRUBY_VERSION"] || "1.1.0"
+MRUBY_VERSION=ENV["MRUBY_VERSION"] || "master"
 
 file :mruby do
   #sh "wget -O mruby.tar.gz https://github.com/mruby/mruby/archive/#{MRUBY_VERSION}.tar.gz"


### PR DESCRIPTION
- RakefileのMRUBY_VERSIONをmasterへ変更
- .travis.ymlに1.3.0とmasterを追加